### PR TITLE
Add product attributes to homepage

### DIFF
--- a/source/assets/stylesheets/base/_typography.scss
+++ b/source/assets/stylesheets/base/_typography.scss
@@ -60,7 +60,7 @@ a {
 }
 
 hr {
-  border-bottom: 2px solid $base-font-color;
+  border-bottom: $bright-border;
   border-left: 0;
   border-right: 0;
   border-top: 0;

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -52,6 +52,7 @@ $playing-card-color: $white;
 // Border
 $base-border-color: lighten($viewport-background-color, 5%);
 $base-border: 1px solid $base-border-color;
+$bright-border: 1px solid $base-font-color;
 $testing-border: 2px dashed #9acd32;
 
 // Focus
@@ -66,6 +67,5 @@ $base-timing: ease;
 
 // Breakpoints
 $mobile-breakpoint: 550px;
-$base-breakpoint: 620px;
 $desktop-breakpoint: 720px;
-$medium-breakpoint: 960px;
+$large-screen-breakpoint: 960px;

--- a/source/assets/stylesheets/components/_components.scss
+++ b/source/assets/stylesheets/components/_components.scss
@@ -1,6 +1,8 @@
 @import "article";
 @import "hand";
+@import "image";
 @import "playing-card";
+@import "promo";
 @import "section";
 @import "site";
 

--- a/source/assets/stylesheets/components/_image.scss
+++ b/source/assets/stylesheets/components/_image.scss
@@ -1,0 +1,6 @@
+.image--cover {
+  height: 100%;
+  object-fit: cover;
+  object-position: center center;
+  width: 100%;
+}

--- a/source/assets/stylesheets/components/_promo.scss
+++ b/source/assets/stylesheets/components/_promo.scss
@@ -1,0 +1,46 @@
+$_media-size: 12rem;
+
+.promo {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+
+  @media(min-width: $large-screen-breakpoint) {
+    flex-direction: row;
+  }
+}
+
+.promo__body {
+  flex: 1 1 auto;
+  order: 0;
+  text-align: center;
+
+  @media(min-width: $large-screen-breakpoint) {
+    text-align: left;
+  }
+}
+
+.promo__media {
+  flex: 0 0 auto;
+  height: $_media-size;
+  width: $_media-size;
+
+  @media(min-width: $mobile-breakpoint) {
+    height: $_media-size * 1.33;
+    width: $_media-size * 1.33;
+  }
+}
+
+.promo__media--left {
+  @media(min-width: $large-screen-breakpoint) {
+    margin-right: $large-spacing;
+    order: -5;
+  }
+}
+
+.promo__media--right {
+  @media(min-width: $large-screen-breakpoint) {
+    margin-left: $large-spacing;
+    order: 5;
+  }
+}

--- a/source/assets/stylesheets/components/_section.scss
+++ b/source/assets/stylesheets/components/_section.scss
@@ -9,8 +9,8 @@
   padding-right: $base-spacing;
 
   @media(min-width: $mobile-breakpoint) {
-    padding-left: $xlarge-spacing;
-    padding-right: $xlarge-spacing;
+    padding-left: $large-spacing + $base-spacing;
+    padding-right: $large-spacing + $base-spacing;
   }
 }
 
@@ -24,7 +24,8 @@
   padding-top: $base-spacing;
 
   @media(min-width: $mobile-breakpoint) {
-    padding: $large-spacing;
+    padding-bottom: $large-spacing;
+    padding-top: $large-spacing;
   }
 }
 
@@ -53,4 +54,9 @@
   @media(min-width: $mobile-breakpoint) {
     max-width: $article-width;
   }
+}
+
+.section__content--centered {
+  text-align: center;
+  width: auto;
 }

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <h2>
-      One thing <br />leads to another...
+      One thing leads&nbsp;to&nbsp;another...
     </h2>
 
     <h3>
@@ -19,5 +19,43 @@
     </p>
 
     <hr />
+  </div>
+</section>
+
+<section class="section">
+  <div class="section__content">
+    <div class="promo">
+      <div class="promo__body">
+        <h2>
+          Play your cards right.
+        </h2>
+
+        <p>
+          The on-the-counter aphrodisiac.
+        </p>
+      </div>
+
+      <div class="promo__media promo__media--right">
+        <img class="image--cover" src="https://www.colorhexa.com/462d35.png" />
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="promo">
+      <div class="promo__body">
+        <h2>
+          One thing leads&nbsp;to&nbsp;another...
+        </h2>
+
+        <p>
+          Kettle Black Ducks get weightier by rank and from one deck to the next.
+        </p>
+      </div>
+
+      <div class="promo__media promo__media--left">
+        <img class="image--cover" src="https://www.colorhexa.com/462d35.png" />
+      </div>
+    </div>
   </div>
 </section>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,42 +1,31 @@
-<section class="section">
-  <div class="section__content">
+<section class="section section--padded section--dark-bkgd">
+  <div class="section__content section__content--centered">
     <h1>
-      Rules & Regulations
+      Playing cards as naughty as&nbsp;you.
     </h1>
 
-    <h2>
-      One thing leads&nbsp;to&nbsp;another...
-    </h2>
-
-    <h3>
-      Variations and Gambits
-    </h3>
-
     <p>
-      Now is the time for all good men to come to the aid of their
-      party. The <a>quick brown fox</a> jumps over the lazy dog, and the
-      dish ran away with the spoon. It might work for you, too.
+      The sexiest, decks-iest fun you'll&nbsp;ever&nbsp;have.
     </p>
-
-    <hr />
   </div>
 </section>
 
-<section class="section">
+<section class="section section--padded">
   <div class="section__content">
     <div class="promo">
       <div class="promo__body">
         <h2>
-          Play your cards right.
+          Intimate.
         </h2>
 
         <p>
-          The on-the-counter aphrodisiac.
+          Create incredible memories. Little Black Deck makes it
+          easy to get together, get comfortable and then get your freak on.
         </p>
       </div>
 
       <div class="promo__media promo__media--right">
-        <img class="image--cover" src="https://www.colorhexa.com/462d35.png" />
+        <img class="image--cover" src="<%= lorem.image '400x400' %>" />
       </div>
     </div>
 
@@ -45,16 +34,36 @@
     <div class="promo">
       <div class="promo__body">
         <h2>
-          One thing leads&nbsp;to&nbsp;another...
+          Inclusive.
         </h2>
 
         <p>
-          Kettle Black Ducks get weightier by rank and from one deck to the next.
+          You're a damn sexy beast and we know it. Little Black Deck is
+          designed for us all — every shake, every shape, every shade.
         </p>
       </div>
 
       <div class="promo__media promo__media--left">
-        <img class="image--cover" src="https://www.colorhexa.com/462d35.png" />
+        <img class="image--cover" src="<%= lorem.image '400x400' %>" />
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="promo">
+      <div class="promo__body">
+        <h2>
+          Inexhaustible.
+        </h2>
+
+        <p>
+          Never play the same game twice. Little Black Deck stimulates
+          the most erotic force of nature — your own imagination.
+        </p>
+      </div>
+
+      <div class="promo__media promo__media--right">
+        <img class="image--cover" src="<%= lorem.image '400x400' %>" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds basic product attribute information to the homepage.

Problem: Users have no way to learn about the product on the site.

Note:
- New promo component

Trello:
https://trello.com/c/q6gqPDFN
https://trello.com/c/gYyi9ocl
