### PR TITLE
Add summary particulars to games

### DIFF
--- a/source/assets/stylesheets/base/_tables.scss
+++ b/source/assets/stylesheets/base/_tables.scss
@@ -12,7 +12,7 @@ thead {
   vertical-align: bottom;
 
   tr {
-    border-bottom: $bright-border;
+    border-bottom: 1px solid $medium-gray;
   }
 }
 
@@ -25,10 +25,11 @@ tr {
 }
 
 th {
+  color: $medium-gray;
   font-family: $heading-font-family;
   font-size: $small-font-size;
-  font-weight: bold;
-  letter-spacing: 0.2rem;
+  font-weight: $base-font-weight;
+  letter-spacing: $wide-letter-spacing;
   text-transform: uppercase;
 }
 

--- a/source/assets/stylesheets/components/_components.scss
+++ b/source/assets/stylesheets/components/_components.scss
@@ -3,6 +3,7 @@
 @import "header";
 @import "image";
 @import "nav";
+@import "particulars";
 @import "playing-card";
 @import "promo";
 @import "section";

--- a/source/assets/stylesheets/components/_particulars.scss
+++ b/source/assets/stylesheets/components/_particulars.scss
@@ -1,0 +1,24 @@
+.particulars {
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: $base-spacing;
+}
+
+.particulars__particular {
+  flex: 1 0 auto;
+  margin-bottom: $small-spacing;
+  margin-right: $base-spacing;
+}
+
+.particulars__label {
+  color: $medium-gray;
+  font-family: $heading-font-family;
+  font-size: $small-font-size;
+  font-weight: $base-font-weight;
+  letter-spacing: $wide-letter-spacing;
+  text-transform: uppercase;
+}
+
+.particulars__data {
+  font-size: $medium-font-size;
+}

--- a/source/games/cheat.html.md.erb
+++ b/source/games/cheat.html.md.erb
@@ -1,8 +1,9 @@
 ---
 title: "Cheat"
+players: "2+"
+game_length: "20 min"
+learning_curve: "Easy"
 ---
-
-# Cheat
 
 Cheat is a card game.
 

--- a/source/games/gin.html.md.erb
+++ b/source/games/gin.html.md.erb
@@ -1,8 +1,9 @@
 ---
 title: "Gin"
+players: "2+"
+game_length: "15 min"
+learning_curve: "Intermediate"
 ---
-
-# Gin
 
 Gin is a card game.
 

--- a/source/games/kalooki.html.md.erb
+++ b/source/games/kalooki.html.md.erb
@@ -1,15 +1,13 @@
 ---
 title: "Kalooki"
-game_length: "2 hrs"
-learning_curve: "Medium"
 players: "3-8"
+game_length: "2 hrs"
+learning_curve: "Difficult"
 ---
 
-# Kalooki
+Kalooki is a Jamaican variant of [contract rummy](rummy.html).
 
-Kalooki is a Jamaican variant of [contract rummy]() for 3-8 players.
-
-To determine how many decks to use, divide the number of players by 2 (round up, if necessary). Mix and shuffle decks together.
+To determine how many decks to use, halve the number of players (round up, if necessary). Mix and shuffle decks together.
 
 ## The Basics
 
@@ -48,7 +46,7 @@ Place the undealt cards (the "stock") face down in the middle of the players.
 | Three runs              | 444           |
 | Four sets               | 3333          |
 | Three sets and one run  | 3334          |
-| Two sets and two runs   | Half and half |
+| Two sets and two runs   | 3344          |
 | One set and three runs  | 3444          |
 | Four runs               | 4444          |
 
@@ -70,7 +68,7 @@ Play progresses clockwise.
 
 ### Calling
 
-Any player can draw the upcard out of turn by "calling" it when it appears on the discard pile. A card is called by saying "Call!" to the player whose turn is about to begin.
+Any player can draw the upcard out of turn by "calling" it when it appears on the discard pile. A card is called by shouting "Call!" to the player whose turn is about to begin.
 
 The in-turn player retains her normal options: to draw either the upcard or a stock card. However, if she intends to draw from the stock, the in-turn player must first give the out-of-turn player both the upcard *and the top stock card (the "penalty" card)* before beginning her turn and resuming normal play.
 

--- a/source/games/oh-hell.html.md.erb
+++ b/source/games/oh-hell.html.md.erb
@@ -1,8 +1,9 @@
 ---
 title: "Oh Hell"
+players: "4+"
+game_length: "20 min"
+learning_curve: "Intermediate"
 ---
-
-# Oh Hell
 
 Oh Hell is a card game.
 

--- a/source/games/poker.html.md.erb
+++ b/source/games/poker.html.md.erb
@@ -1,8 +1,9 @@
 ---
 title: "Poker"
+players: "2+"
+game_length: "5 min"
+learning_curve: "Intermediate"
 ---
-
-# Poker
 
 Poker is a game for 2-6 players.
 

--- a/source/games/rummy.html.md.erb
+++ b/source/games/rummy.html.md.erb
@@ -1,8 +1,9 @@
 ---
 title: "Rummy"
+players: "2"
+game_length: "20 min"
+learning_curve: "Easy"
 ---
-
-# Rummy
 
 Rummy is a card game.
 

--- a/source/games/spit.html.md.erb
+++ b/source/games/spit.html.md.erb
@@ -1,10 +1,11 @@
 ---
 title: "Spit"
+players: "2"
+game_length: "20 min"
+learning_curve: "Easy"
 ---
 
-# Spit
-
-Spit is a card game for 2 players.
+Spit is a card game.
 
 ## The Basics
 

--- a/source/layouts/article.erb
+++ b/source/layouts/article.erb
@@ -15,6 +15,42 @@
     <main class="site__main" role="main">
       <section class="section section--padded">
         <article class="section__content--slim article">
+          <h1>
+            <%= current_page.data.title %>
+          </h1>
+
+          <div class="particulars">
+            <dl class="particulars__particular">
+              <dt class="particulars__label">
+                Players
+              </dt>
+
+              <dd class="particulars__data">
+                <%= current_page.data.players %>
+              </dd>
+            </dl>
+
+            <dl class="particulars__particular">
+              <dt class="particulars__label">
+                Game Length
+              </dt>
+
+              <dd class="particulars__data">
+                <%= current_page.data.game_length %>
+              </dd>
+            </dl>
+
+            <dl class="particulars__particular">
+              <dt class="particulars__label">
+                Learning Curve
+              </dt>
+
+              <dd class="particulars__data">
+                <%= current_page.data.learning_curve %>
+              </dd>
+            </dl>
+          </div>
+
           <%= yield %>
         </article>
       </section>


### PR DESCRIPTION
This PR adds summary particulars (number of players, difficulty, etc) to games.

Problem: Visitors have to read the entire game rules to get a basic sense of a game.

Trello:
https://trello.com/c/w8YWcDN5

## After

<img width="680" alt="Screen Shot 2019-03-24 at 11 28 34 AM" src="https://user-images.githubusercontent.com/28635708/54881609-03262280-4e28-11e9-821c-12583afe5475.png">
