### PR TITLE
Add email signup, improve borders

### DIFF
--- a/source/assets/stylesheets/base/_forms.scss
+++ b/source/assets/stylesheets/base/_forms.scss
@@ -61,7 +61,7 @@ textarea {
   }
 
   &::placeholder {
-    color: tint($base-font-color, 40%);
+    color: $dimmed-font-color;
   }
 }
 

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -66,7 +66,7 @@ $playing-card-color: $white;
 $base-border-color: $viewport-light-tint;
 $base-border: 1px solid $base-border-color;
 $bright-border: 1px solid $base-font-color;
-$testing-border: 2px dashed #9acd32;
+$invisible-border: 1px solid $viewport-background-color;
 
 // Focus
 $focus-outline-color: transparentize($action-color, 0.4);

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -54,7 +54,7 @@ $red: #dd0000;
 // Background Colors
 $viewport-background-color: $dark-gray;
 $viewport-dark-tint: darken($viewport-background-color, 5%);
-$viewport-light-tint: lighten($viewport-background-color, 5%);
+$viewport-light-tint: lighten($viewport-background-color, 7%);
 
 // Domain Colors
 $base-font-color: $light-gray;
@@ -66,7 +66,7 @@ $playing-card-color: $white;
 $base-border-color: $viewport-light-tint;
 $base-border: 1px solid $base-border-color;
 $bright-border: 1px solid $base-font-color;
-$invisible-border: 1px solid $viewport-background-color;
+$background-border: 1px solid $viewport-background-color;
 
 // Focus
 $focus-outline-color: transparentize($action-color, 0.4);

--- a/source/assets/stylesheets/components/_article.scss
+++ b/source/assets/stylesheets/components/_article.scss
@@ -2,20 +2,20 @@ $_list-indent: $small-spacing * 1.5;
 
 .article {
   h1 {
-    border-bottom: 4px solid rgba($base-font-color, 0.1);
+    border-bottom: 0.25rem solid $viewport-light-tint;
     margin-bottom: $base-spacing;
     margin-top: 0;
     padding-bottom: $small-spacing;
   }
 
   h2 {
-    border-bottom: 2px solid rgba($base-font-color, 0.1);
+    border-bottom: 0.125rem solid $viewport-light-tint;
     margin-top: $xlarge-spacing;
     padding-bottom: $small-spacing;
   }
 
   h3 {
-    border-bottom: 2px solid rgba($base-font-color, 0.1);
+    border-bottom: 0.125rem solid $viewport-light-tint;
     margin-top: $large-spacing;
     padding-bottom: $small-spacing;
   }

--- a/source/assets/stylesheets/components/_components.scss
+++ b/source/assets/stylesheets/components/_components.scss
@@ -8,5 +8,6 @@
 @import "playing-card";
 @import "promo";
 @import "section";
+@import "signup";
 @import "site";
 @import "suggestion";

--- a/source/assets/stylesheets/components/_playing-card.scss
+++ b/source/assets/stylesheets/components/_playing-card.scss
@@ -19,7 +19,7 @@ $_playing-card-width: $_pip-size * 5.5;
 .playing-card__face {
   align-items: flex-start;
   background-color: $playing-card-color;
-  border: 2px solid $viewport-background-color;
+  border: 0.1rem solid $viewport-background-color;
   border-radius: $large-border-radius $large-border-radius 0 0;
   display: flex;
   flex-direction: column;

--- a/source/assets/stylesheets/components/_signup.scss
+++ b/source/assets/stylesheets/components/_signup.scss
@@ -1,0 +1,30 @@
+.signup {
+  @media(min-width: $desktop-breakpoint) {
+    align-items: center;
+    display: flex;
+  }
+
+  input {
+    border: $invisible-border;
+    height: $large-spacing;
+  }
+}
+
+.signup__email {
+  border-radius: $base-border-radius;
+  margin-bottom: $small-spacing;
+
+  @media(min-width: $desktop-breakpoint) {
+    border-radius: $base-border-radius 0 0 $base-border-radius;
+    margin: 0;
+  }
+}
+
+.signup__submit {
+  border-radius: $base-border-radius;
+
+  @media(min-width: $desktop-breakpoint) {
+    border-radius: 0 $base-border-radius $base-border-radius 0;
+    margin: 0;
+  }
+}

--- a/source/assets/stylesheets/components/_signup.scss
+++ b/source/assets/stylesheets/components/_signup.scss
@@ -5,7 +5,7 @@
   }
 
   input {
-    border: $invisible-border;
+    border: $background-border;
     height: $large-spacing;
   }
 }

--- a/source/assets/stylesheets/utilities/_utilities.scss
+++ b/source/assets/stylesheets/utilities/_utilities.scss
@@ -13,5 +13,5 @@
 }
 
 .u-see {
-  border: $testing-border;
+  border: 2px dashed #9acd32;
 }

--- a/source/assets/stylesheets/utilities/_utilities.scss
+++ b/source/assets/stylesheets/utilities/_utilities.scss
@@ -13,5 +13,5 @@
 }
 
 .u-see {
-  border: 2px dashed #9acd32;
+  border: 0.125rem dashed #9acd32;
 }

--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -1,4 +1,53 @@
 <section class="section section--padded section--dark-bkgd">
+  <div id="mc_embed_signup" class="section__content section__content--slim section__content--centered">
+    <p>
+      Be the first to know when we have decks on deck.
+    </p>
+
+    <form
+      action="https://littleblackdeck.us20.list-manage.com/subscribe/post?u=76ace10359b303869643fc218&amp;id=27376f1d20"
+      method="post"
+      id="mc-embedded-subscribe-form"
+      name="mc-embedded-subscribe-form"
+      target="_blank"
+      novalidate
+    >
+      <div id="mce-responses">
+        <div id="mce-error-response" style="display:none">
+        </div>
+
+        <div id="mce-success-response" style="display:none">
+        </div>
+      </div>
+
+      <div id="mc_embed_signup_scroll" class="signup">
+        <div style="position: absolute; left: -5000px;" aria-hidden="true"> <!-- input to catch bots -->
+          <input type="text" name="b_76ace10359b303869643fc218_27376f1d20" tabindex="-1" value="">
+        </div>
+
+        <input
+          type="email"
+          aria-label="email address"
+          placeholder="email"
+          name="EMAIL"
+          id="mce-EMAIL"
+          class="signup__email"
+        >
+
+        <input
+          type="submit"
+          value="Notify me"
+          name="subscribe"
+          id="mc-embedded-subscribe"
+          class="signup__submit"
+        >
+      </div>
+    </form>
+  </div>
+</section>
+
+
+<section class="section section--dark-bkgd">
   <div class="section__content section__content--centered">
     <small class="fine-print">
       &copy; <%= Time.now.year %> Keiran King, Raisha King.


### PR DESCRIPTION
This PR adds an email signup section to the site footer. The form is connected to a Mailchimp campaign.

Problem: Visitors cannot indicate intent to buy the product.

Trello:
https://trello.com/c/4WVNtB3S

## After

<img width="529" alt="Screen Shot 2019-03-26 at 12 26 42 PM" src="https://user-images.githubusercontent.com/28635708/55015055-88453f00-4fc2-11e9-9153-d9ccd09ef88c.png">
