### PR TITLE
Grid-based lists

### DIFF
--- a/source/assets/stylesheets/components/_article.scss
+++ b/source/assets/stylesheets/components/_article.scss
@@ -1,4 +1,4 @@
-$_list-indent: $small-spacing * 1.5;
+$_list-indent: $base-spacing;
 
 .article {
   h1 {
@@ -20,46 +20,49 @@ $_list-indent: $small-spacing * 1.5;
     padding-bottom: $small-spacing;
   }
 
+  p + ol,
+  p + ul {
+    margin-bottom: $small-spacing;
+  }
+
+  li {
+    display: grid;
+    grid-template-columns: $_list-indent auto;
+
+    > * {
+      grid-column: 2;
+    }
+
+    &::before {
+      color: $dimmed-font-color;
+      grid-column: 1;
+    }
+  }
+
   ol {
     counter-reset: article-list-counter;
 
     > li {
       counter-increment: article-list-counter;
-      margin-left: $_list-indent;
-      position: relative;
-
-      @media(min-width: $mobile-breakpoint) {
-        margin-left: 0;
-      }
 
       &::before {
-        color: $dimmed-font-color;
         content: counter(article-list-counter);
-        font-family: $heading-font-family;
-        font-weight: $heavy-font-weight;
-        left: -$_list-indent;
-        position: absolute;
-        text-align: center;
-        top: 0.075rem;
       }
     }
   }
 
+  > ol {
+    margin-left: 0;
+
+    @media(min-width: $large-screen-breakpoint) {
+      margin-left: -$_list-indent;
+    }
+  }
+
   ul {
-    margin-left: $_list-indent;
-    margin-top: -$xsmall-spacing;
-    padding-bottom: $small-spacing;
-
     > li {
-      position: relative;
-
       &::before {
-        color: $dimmed-font-color;
         content: "\2666";
-        font-size: $small-font-size;
-        left: -$_list-indent;
-        position: absolute;
-        top: 0.25rem;
       }
     }
   }


### PR DESCRIPTION
Problem: 
• Articles need different lists than default sitewide list styles.
• Article lists currently have a clumsy implementation.

Solution:
• Ordered and unordered lists use simple nested CSS grids.
• Ordered lists display numbers and pop flush with body text on large screens.
• Unordered lists display bullets.

Trello:
https://trello.com/c/G9DZyb2m

## After

![Screen Shot 2019-04-12 at 2 37 59 PM](https://user-images.githubusercontent.com/28635708/56059634-7db0d680-5d32-11e9-8de3-e76bd48cf73a.png)
